### PR TITLE
handle json parsing errors

### DIFF
--- a/lib/bs/movement.ex
+++ b/lib/bs/movement.ex
@@ -96,7 +96,11 @@ defmodule Bs.Movement.Worker do
       response
       |> notify(id: world.game_id, snake_id: snake.id, tc: tc)
       |> Map.get(:body)
-      |> Poison.decode!()
+      |> Poison.decode()
+      |> case do
+        {:ok, j} -> j
+        {:error, _, _} -> %{}
+      end
 
     changeset = Move.changeset(%Move{}, params)
 

--- a/lib/bs/world/factory.ex
+++ b/lib/bs/world/factory.ex
@@ -126,7 +126,11 @@ defmodule Bs.World.Factory.Worker do
       ]
     )
 
-    json = Poison.decode!(response.body)
+    json =
+      case Poison.decode(response.body) do
+        {:ok, j} -> j
+        {:error, _, _} -> %{}
+      end
 
     model = %Snake{url: url, id: id}
 


### PR DESCRIPTION
the json parsing just threw errors if there was any problem with the json, for example if the snake returned a 400 and no body, this would cause json parsing to fail. This should fix #4