### PR TITLE
add existing snake coords to world gen so snakes don't spawn on top of each other

### DIFF
--- a/lib/bs/world.ex
+++ b/lib/bs/world.ex
@@ -54,7 +54,11 @@ defmodule Bs.World do
     world
   end
 
-  def rand_unoccupied_space(%{width: w, height: h} = world, buffer \\ 0)
+  def rand_unoccupied_space(
+        %{width: w, height: h} = world,
+        buffer \\ 0,
+        excluded_points \\ []
+      )
       when w > 0 and h > 0 do
     all =
       Stream.flat_map(buffer..(world.width - buffer - 1), fn x ->
@@ -63,7 +67,7 @@ defmodule Bs.World do
         end)
       end)
 
-    occupied = get_occupied_spaces(world, buffer)
+    occupied = get_occupied_spaces(world, buffer, excluded_points)
 
     available =
       Enum.to_list(Stream.filter(all, fn p -> !MapSet.member?(occupied, p) end))
@@ -75,9 +79,11 @@ defmodule Bs.World do
     end
   end
 
-  defp get_occupied_spaces(world, buffer) do
-    spaces = Stream.flat_map(world.snakes, & &1.coords)
-    spaces = Stream.concat(spaces, world.food)
+  defp get_occupied_spaces(world, buffer, excluded_points \\ []) do
+    spaces =
+      Stream.flat_map(world.snakes, & &1.coords)
+      |> Stream.concat(world.food)
+      |> Stream.concat(excluded_points)
 
     spaces =
       case buffer do

--- a/lib/bs/world.ex
+++ b/lib/bs/world.ex
@@ -79,7 +79,8 @@ defmodule Bs.World do
     end
   end
 
-  defp get_occupied_spaces(world, buffer, excluded_points \\ []) do
+  defp get_occupied_spaces(world, buffer, excluded_points) do
+    # this is actually probably empty because the field is captured without any data
     spaces =
       Stream.flat_map(world.snakes, & &1.coords)
       |> Stream.concat(world.food)

--- a/lib/bs/world/factory.ex
+++ b/lib/bs/world/factory.ex
@@ -2,7 +2,6 @@ alias Bs.Snake
 alias Bs.World
 alias Bs.Notification
 alias Bs.World.Factory.Worker
-alias Bs.Point
 
 defmodule Bs.World.Factory do
   @timeout 4900
@@ -84,7 +83,7 @@ defmodule Bs.World.Factory do
     )
 
     world = World.stock_food(world)
-    world = put_in(world.snakes, set_snake_coords(snakes, world, game))
+    put_in(world.snakes, set_snake_coords(snakes, world, game))
   end
 
   defp set_snake_coords(snakes, world, game) do
@@ -104,7 +103,7 @@ defmodule Bs.World.Factory do
     set_snake_coords(tail, world, game, [head | acc])
   end
 
-  defp set_snake_coords([], world, game, acc) do
+  defp set_snake_coords([], _, _, acc) do
     acc
   end
 end

--- a/lib/bs/world/factory.ex
+++ b/lib/bs/world/factory.ex
@@ -2,6 +2,7 @@ alias Bs.Snake
 alias Bs.World
 alias Bs.Notification
 alias Bs.World.Factory.Worker
+alias Bs.Point
 
 defmodule Bs.World.Factory do
   @timeout 4900
@@ -82,19 +83,29 @@ defmodule Bs.World.Factory do
       data: %{}
     )
 
-    world = put_in(world.snakes, snakes)
-
     world = World.stock_food(world)
+    world = put_in(world.snakes, set_snake_coords(snakes, world, game))
+  end
 
-    update_in(world.snakes, fn snakes ->
-      for snake <- snakes do
-        {:ok, point} = World.rand_unoccupied_space(world, 1)
+  defp set_snake_coords(snakes, world, game) do
+    set_snake_coords(snakes, world, game, [])
+  end
 
-        coords = List.duplicate(point, game.snake_start_length)
+  defp set_snake_coords([head | tail], world, game, acc) do
+    {:ok, point} =
+      World.rand_unoccupied_space(
+        world,
+        1,
+        Enum.map(acc, &List.first(&1.coords))
+      )
 
-        put_in(snake.coords, coords)
-      end
-    end)
+    coords = List.duplicate(point, game.snake_start_length)
+    head = Map.put(head, :coords, coords)
+    set_snake_coords(tail, world, game, [head | acc])
+  end
+
+  defp set_snake_coords([], world, game, acc) do
+    acc
   end
 end
 


### PR DESCRIPTION
`world.snakes` in the get_occupied_spaces function doesn't contain any coords for the snakes yet during snake coord generation. This pr changes the snake coord generation to a recursive function, that maintains all the snakes that have already been generated in the accumulator, and passes that in as additional spaces to exclude. This should fix #12 