### PR TITLE
ignore name in api call

### DIFF
--- a/lib/bs/snake.ex
+++ b/lib/bs/snake.ex
@@ -33,14 +33,13 @@ defmodule Bs.Snake do
       :color,
       :head_type,
       :head_url,
-      :name,
       :secondary_color,
       :tail_type,
       :taunt,
       :url
     ]
 
-    required = [:name]
+    required = []
 
     model
     |> cast(params, permitted)

--- a/lib/bs/world/factory.ex
+++ b/lib/bs/world/factory.ex
@@ -104,7 +104,7 @@ defmodule Bs.World.Factory.Worker do
 
   def run(permalink, gameid, opts \\ [])
 
-  def run(%{id: id, url: url}, gameid, data) do
+  def run(%{id: id, url: url, name: name}, gameid, data) do
     start_url = "#{url}/start"
 
     {tc, response} =
@@ -132,7 +132,7 @@ defmodule Bs.World.Factory.Worker do
         {:error, _, _} -> %{}
       end
 
-    model = %Snake{url: url, id: id}
+    model = %Snake{url: String.trim(url, "/"), id: id, name: name}
 
     changeset = Snake.changeset(model, json)
 

--- a/lib/bs_web/models/snake_form.ex
+++ b/lib/bs_web/models/snake_form.ex
@@ -5,11 +5,12 @@ defmodule BsWeb.SnakeForm do
 
   embedded_schema do
     field(:url)
+    field(:name)
     field(:delete, :boolean, virtual: true)
   end
 
   def changeset(snake, params \\ %{}) do
     snake
-    |> cast(params, [:url, :delete])
+    |> cast(params, [:url, :name, :delete])
   end
 end

--- a/lib/bs_web/templates/game/_form.html.eex
+++ b/lib/bs_web/templates/game/_form.html.eex
@@ -52,6 +52,7 @@
     <thead>
       <tr>
         <td>url</td>
+        <td>name</td>
         <td>delete</td>
       </tr>
     </thead>
@@ -61,6 +62,7 @@
           <td><%= url_input g, :url,
               title: "Please enter a valid url (e.g. http://localhost:4000)",
               pattern: "https?://.+" %></td>
+          <td><%= text_input g, :name %></td>
           <td><%= checkbox g, :delete %></td>
         </tr>
       <% end %>


### PR DESCRIPTION
name is configured on game start, instead of via start api call. Also handle the case when there is a trailing slash on the url, it will now be trimmed