### PR TITLE
max history can be set via environment variable MAX_HISTORY

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -15,6 +15,8 @@ config :bs, BsWeb.Endpoint,
 
 config :bs, start_timeout: 10_000
 
+config :bs, :max_history, System.get_env("MAX_HISTORY")
+
 config :bs, :http, HTTPoison
 
 config :bs, ecto_repos: [BsRepo]

--- a/lib/bs/game_state.ex
+++ b/lib/bs/game_state.ex
@@ -4,7 +4,8 @@ defmodule Bs.GameState do
   alias Bs.Snake
   alias Bs.World
 
-  @max_history 20
+  @default_max_history 20
+  @max_history Application.get_env(:bs, :max_history, 20)
 
   @statuses [:cont, :replay, :halted, :suspend]
 
@@ -90,7 +91,6 @@ defmodule Bs.GameState do
       |> Death.reap()
       |> Map.update!(:world, &World.step/1)
 
-    IO.inspect(state)
     if done?(state), do: step_done(state), else: state
   end
 
@@ -141,7 +141,14 @@ defmodule Bs.GameState do
   end
 
   defp save_history(%{world: h} = state) do
-    update_in(state.hist, fn t -> [h | Enum.take(t, @max_history)] end)
+    max_history =
+      case Integer.parse(@max_history) do
+        {val, _} -> val
+        :error -> @default_max_history
+      end
+
+    IO.inspect(max_history)
+    update_in(state.hist, fn t -> [h | Enum.take(t, max_history)] end)
   end
 
   defp who_died_last(state) do

--- a/lib/bs/game_state.ex
+++ b/lib/bs/game_state.ex
@@ -147,7 +147,6 @@ defmodule Bs.GameState do
         :error -> @default_max_history
       end
 
-    IO.inspect(max_history)
     update_in(state.hist, fn t -> [h | Enum.take(t, max_history)] end)
   end
 


### PR DESCRIPTION
If the environment variable is not available, the server will default to 20 turns