### PR TITLE
make name optional in json parsing

### DIFF
--- a/assets/elm/src/Decoder.elm
+++ b/assets/elm/src/Decoder.elm
@@ -106,7 +106,7 @@ snakeDecoder =
         |> required "coords" (list vec2Decoder)
         |> required "health" int
         |> required "id" string
-        |> required "name" string
+        |> optional "name" string ""
         |> required "taunt" (maybe string)
         |> (string
                 |> maybe


### PR DESCRIPTION
this makes the name option in the json parser, so that if the name is left out of the form, the games will still play