### PR TITLE
Detect overlapping head-on collisions

### DIFF
--- a/lib/bs/death.ex
+++ b/lib/bs/death.ex
@@ -161,7 +161,9 @@ defmodule Bs.Death do
 
       Stream.map(snakes, fn other ->
         cond do
-          other.id != snake.id and head == hd(other.coords) and
+          other.id != snake.id and 
+              (head == hd(other.coords) 
+               or (length(snake.coords) > 1 and length(other.coords) > 1 and hd(tl(snake.coords)) == hd(other.coords) and head == hd(tl(other.coords)))) and
               length(snake.coords) <= length(other.coords) ->
             %HeadCollisionCause{with: other.id}
 

--- a/test/bs/death_test.exs
+++ b/test/bs/death_test.exs
@@ -20,7 +20,9 @@ defmodule DeathTest do
         build(:snake, id: 3, coords: [p(1, 0), p(2, 0), p(3, 0)]),
         build(:snake, id: 4, coords: [p(101, 0)]),
         build(:snake, id: 5, coords: [p(0, 0)]),
-        build(:snake, id: 6, coords: [p(9, 0), p(9, 0)])
+        build(:snake, id: 6, coords: [p(9, 0), p(9, 0)]),
+        build(:snake, id: 7, coords: [p(5, 0), p(5, 1)]),
+        build(:snake, id: 8, coords: [p(5, 1), p(5, 0), p(6, 0)])
       ]
 
       world = build(:world, width: 100, height: 100, snakes: snakes)
@@ -35,8 +37,8 @@ defmodule DeathTest do
       live = state.world.snakes
       dead = state.world.dead_snakes
 
-      assert [0] == for(x <- live, do: x.id)
-      assert [1, 2, 3, 4, 5, 6] == for(x <- dead, do: x.id)
+      assert [0, 8] == for(x <- live, do: x.id)
+      assert [1, 2, 3, 4, 5, 6, 7] == for(x <- dead, do: x.id)
     end
 
     test "sets the cause of death", %{state: state} do
@@ -68,7 +70,16 @@ defmodule DeathTest do
                    ]
                  }
                },
-               {6, %Death{turn: 0, causes: [%SelfCollisionCause{}]}}
+               {6, %Death{turn: 0, causes: [%SelfCollisionCause{}]}},
+               {
+                 7,
+                 %Death{
+                   turn: 0,
+                   causes: [
+                     %HeadCollisionCause{with: 8}
+                   ]
+                 }
+               },
              ] == causes
     end
   end


### PR DESCRIPTION
This addresses #48.

I couldn't get a local environment running the tests -- I hope I got it right. It does not handle the case of detecting overlapping head-on collisions for snakes with length 1, but that would require significant changes.