### PR TITLE
Fix for minor jitters with board view

### DIFF
--- a/assets/elm/src/Game/View.elm
+++ b/assets/elm/src/Game/View.elm
@@ -265,7 +265,7 @@ row =
 
 viewPort : List (Attribute msg) -> List (Html msg) -> Html msg
 viewPort =
-    styled row [ Css.height (vh 100), Css.width (vw 100) ]
+    styled row [ Css.height (vh 100) ]
 
 
 avControls : List (Attribute msg) -> List (Html msg) -> Html msg


### PR DESCRIPTION
This fixes a minor jitter when the width of the board items boundaries exceed the width of the board. 

Tested this change in the dev tools in Edge and Chrome on Windows. 