### PR TITLE
Fix copy-paste error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,8 +267,7 @@ endpoint on each turn. The game server expects a JSON response within 200ms.
 
 ### POST `/end`
 
-A request including all the current game information will be issued to this
-endpoint on each turn.
+A request including end game information such as winners, dead snakes, and death reasons will be issued to this endpoint at the end of the game.
 
 Possible death causes are:
 


### PR DESCRIPTION
Just a small copy-paste error in the readme. The `/end` hook is actually only sent once per game, and only includes end-game information, not the full board state.

cc @john-swu 